### PR TITLE
Object destructuring instead of defining property

### DIFF
--- a/backend/modules/ffmpeg/MediaContentApiHandler.js
+++ b/backend/modules/ffmpeg/MediaContentApiHandler.js
@@ -69,7 +69,10 @@ class SubtitleApiHandler extends RequestHandler {
     const response = { subtitles };
 
     let { streams } = this.item.attributes;
-    if (!streams) streams = await FFProbe.getInfo(this.filePath).streams;
+    if (!streams) {
+      const probe = await FFProbe.getInfo(this.filePath);
+      ({ streams } = probe);
+    }
 
     streams.forEach((str) => {
       let name = str.tags ? str.tags.language : str.codec_long_name;


### PR DESCRIPTION
@OwenRay so this is a bit strange, but if I use the code provided here, I am able to play all my mp4 files. There are a few issues (such as thumbnails not showing up) but the actual videos play. 

When I don't use the object destructuring like this, then this line doesn't wait for the promise to resolve:
```
await FFProbe.getInfo(this.filePath).streams;
```
The `streams` variable remains undefined and we see the error that I described in my issue (https://github.com/OwenRay/Remote-MediaServer/issues/62). 

I feel like there is a deeper issue here that I don't quite understand, perhaps its due to my particular mp4's that I am having issues with, but this certainly seems to fix it. Please let me know if you have any thoughts or concerns about this.

Thank you!